### PR TITLE
chore: Display Webpack compilation progress during `npm start`

### DIFF
--- a/mdc-101/complete/package.json
+++ b/mdc-101/complete/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/mdc-101/starter/package.json
+++ b/mdc-101/starter/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/mdc-102/complete/package.json
+++ b/mdc-102/complete/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/mdc-102/starter/package.json
+++ b/mdc-102/starter/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/mdc-103/complete/package.json
+++ b/mdc-103/complete/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/mdc-103/starter/package.json
+++ b/mdc-103/starter/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/mdc-112/complete/package.json
+++ b/mdc-112/complete/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/mdc-112/starter/package.json
+++ b/mdc-112/starter/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server --progress"
   },
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Without `--progress`, there's no indication that anything is happening, which is bad devex.