### PR TITLE
fix: Replace imported stylesheet(#93)

### DIFF
--- a/mdc-103/complete/home.scss
+++ b/mdc-103/complete/home.scss
@@ -2,7 +2,7 @@
 @import "@material/drawer/mdc-drawer";
 @import "@material/list/mdc-list";
 @import "@material/image-list/mdc-image-list";
-@import "@material/ripple/mixins";
+@import "@material/ripple/mdc-ripple";
 @import "@material/typography/mdc-typography";
 @import "@material/elevation/mdc-elevation";
 


### PR DESCRIPTION
Applies the [solution from arief135](https://github.com/material-components/material-components-web-codelabs/issues/139#issuecomment-663077779) to recurring duplicate issues  (material-components#139, material-components#198, material-components#155). Build should complete without error without applying the earlier [workaround](https://github.com/material-components/material-components-web-codelabs/issues/139#issuecomment-632870087). However, the [MDC-103 Web codelab instructions](https://codelabs.developers.google.com/codelabs/mdc-103-web/#2) **must be changed** accordingly to prevent further issues.